### PR TITLE
Multi publish

### DIFF
--- a/hookbox/api/internal.py
+++ b/hookbox/api/internal.py
@@ -21,6 +21,12 @@ class HookboxAPI(object):
         channel = self.server.get_channel(None, channel_name)
         channel.publish(self, payload, needs_auth=send_hook, originator=originator)
 
+    def publish_multi(self, channel_name_list, payload='null', originator=None, send_hook=False):
+        for channel_name in channel_name_list:
+            if self.server.exists_channel(channel_name):
+                channel = self.server.get_channel(None, channel_name)
+                channel.publish(self, payload, needs_auth=send_hook, originator=originator)
+
     def unsubscribe(self, channel_name, name, send_hook=False):
         if not self.server.exists_channel(channel_name):
             raise ExpectedException("Channel %s doesn't exist" % (channel_name,))

--- a/hookbox/api/web.py
+++ b/hookbox/api/web.py
@@ -47,6 +47,17 @@ class HookboxWebAPI(object):
         start_response('200 Ok', [])
         return json.dumps([True, {}])
 
+    def render_publish_multi(self, form, start_response):
+        channel_names = form.get('channel_names', None)
+        if not channel_names:
+            raise ExpectedException("Missing channel_names")
+        channel_name_list = channel_names.split(',')
+        payload = form.get('payload', 'null')
+        originator = form.get('originator', None)
+        send_hook = form.get('send_hook', '0') == '1'
+        self.api.publish_multi(channel_name_list, payload, originator, send_hook)
+        start_response('200 Ok', [])
+        return json.dumps([True, {}])
 
     def render_unsubscribe(self, form, start_response):
         channel_name = form.get('channel_name', None)


### PR DESCRIPTION
Hi Michael,

Hookbox looks like the most amazing thing since XMLHttpRequest.  Nice work.

For my use-case, I need the ability to publish to a large number of channels, each with a small number of potential users.  So, I added publish_multi.  I'd love it if this (or equivalent--I'm certainly not wedding to my impl) could make it into the main tree.

Thanks.

Also, rather than run it as a command-line program, I'd like to invoke it in my management scripts (that mange virtualenvs, logging, etc).  I've had to hack it rather badly to do this.  Any chance that Hookbox could be made available as a library too?  I.e., instead of just hookbox.start.main() which uses sys.argv, if there was a hookbox.start.start_hookbox(config_kwargs)?

Thanks again,
Dan
