### PR TITLE
Bug for Windows' (Python2.6) lack of support for the %T on strftime

### DIFF
--- a/hookbox/admin/admin.py
+++ b/hookbox/admin/admin.py
@@ -98,7 +98,7 @@ class HookboxAdminApp(object):
             "form": form_body and cgi.escape(str(form_body)),
             "cookie": cookie_string and cgi.escape(str(cookie_string)),
             "err": err and cgi.escape(str(err)),
-            "date": datetime.datetime.now().strftime("%A %d-%b-%y %T %Z")
+            "date": datetime.datetime.now().strftime("%A %d-%b-%y %H:%M:%S %Z")
         }
         self.webhooks_history.append(frame)
         while len(self.webhooks_history) > WEBHOOK_HISTORY_SIZE:


### PR DESCRIPTION
I have hookbox working perfectly on Mac OS, but when I try it on windows XP (official Python2.6) on two machines, clients fail to connect because of:

2010-09-22 13:28:49,358 - access - INFO - Incoming WebSocket connection 127.0.0.1       localhost:8001
2010-09-22 13:28:49,375 - HookboxConn - WARNING - Unexpected error: Invalid format string
Traceback (most recent call last):
  File "E:\Python26\lib\site-packages\hookbox-0.3.3-py2.6.egg\hookbox\protocol.py", line 68, in run
    f(fid, fargs)
  File "E:\Python26\lib\site-packages\hookbox-0.3.3-py2.6.egg\hookbox\protocol.py", line 97, in frame_CONNECT
    self.server.connect(self)
  File "E:\Python26\lib\site-packages\hookbox-0.3.3-py2.6.egg\hookbox\server.py", line 220, in connect
    success, options = self.http_request('connect', conn.get_cookie(), form, conn=conn)
  File "E:\Python26\lib\site-packages\hookbox-0.3.3-py2.6.egg\hookbox\server.py", line 192, in http_request
    self.admin.webhook_event(path_name, url, response.status, False, body, form_body, cookie_string, "Invalid json response")
  File "E:\Python26\lib\site-packages\hookbox-0.3.3-py2.6.egg\hookbox\admin\admin.py", line 101, in webhook_event
    "date": datetime.datetime.now().strftime("%A %d-%b-%y %T %Z") 
ValueError: Invalid format string

I did a few tests and the flag %T is not supported on Windows. In order to fix, I replaced %T by the more verbose solution %H:%M:%S.

I will be giving out hookbox to students, for a university assignment, and I would need this fix to be on pypi really soon.

Thank you.
