### PR TITLE
Remove hard-coded IP addresses from example index.html

### DIFF
--- a/examples/python_graphic_eq/index.html
+++ b/examples/python_graphic_eq/index.html
@@ -2,7 +2,12 @@
     <head>
         <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
         <script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.2/jquery-ui.min.js"></script>
-        <script src="http://127.0.0.1:2974/static/hookbox.js"></script>
+        <script type="text/javascript"> 
+            // Load the hookbox.js from the current host but changing the port to 2974.
+            server = location.protocol + '//' + location.hostname + ':2974';
+            // Dynamically inserts the code to load the script into the page.
+            document.write('<scr'+'ipt src="' + server + '/static/hookbox.js"></scr'+'ipt>');
+        </script>
         <link rel="stylesheet" href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.2/themes/ui-lightness/jquery-ui.css" type="text/css" />
     </head> 
     <body>

--- a/examples/python_scope/index.html
+++ b/examples/python_scope/index.html
@@ -2,9 +2,14 @@
     <head>
         <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
         <script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.2/jquery-ui.min.js"></script>
-        <script src="http://10.2.103.1:2974/static/hookbox.js"></script>
+        <script type="text/javascript"> 
+            // Load the hookbox.js from the current host but changing the port to 2974.
+            server = location.protocol + '//' + location.hostname + ':2974';
+            // Dynamically inserts the code to load the script into the page.
+            document.write('<scr'+'ipt src="' + server + '/static/hookbox.js"></scr'+'ipt>');
+        </script>
         <link rel="stylesheet" href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.2/themes/ui-lightness/jquery-ui.css" type="text/css" />
-        <script src="http://10.2.103.1:8080/static/jquery.flot.min.js"></script>       
+        <script src="/static/jquery.flot.min.js"></script>       
     </head> 
     <body>
 


### PR DESCRIPTION
I wrote a few lines of javascript so that the python examples would work properly if the server is running on a different IP address.  One of the examples currently has a 10.x.x.x IP address hard-coded in which will basically never work as written.
