### PR TITLE
Flesh out implementation of user to user messages

### DIFF
--- a/docs/source/web.rst
+++ b/docs/source/web.rst
@@ -354,3 +354,82 @@ Server Replies:
 
 
 The callback host is now set to ``1.2.3.4`` and the port is now ``80``.
+
+
+get_user_info
+================
+
+Returns all settings and attributes of a user.
+
+Required Form Variables:
+
+* ``security_token``: The password specified in the config as ``-r`` or ``--api-security-token``.
+* ``user_name``: The target user.
+
+Returns json:
+
+[ success (boolean) , details (object) ]
+
+Example:
+
+Client Requests URL:
+
+.. sourcecode:: none
+
+    /web/get_user_info?security_token=yo&user_name=mcarter
+
+
+Server Replies:
+
+
+.. sourcecode:: javascript
+
+    [
+        true,
+        {
+            "channels": [
+                "testing"
+            ],
+            "connections": [
+                "467412414c294f1a9d1759ace01455d9"
+            ],
+            "name": "mcarter",
+            "options": {
+                "reflective": true,
+                "moderated_message": true
+            }
+        }
+    ]
+
+
+set_user_options
+===================
+
+Set the options on a user.
+
+Required Form Variables:
+
+* ``security_token``: The password specified in the config as ``-r`` or ``--api-security-token``.
+* ``user_name``: The target user.
+
+Optional Form Variables:
+
+* ``reflective``: json boolean
+* ``moderated_message``: json boolean
+
+Example:
+
+Client Requests URL:
+
+.. sourcecode:: none
+
+    /web/set_user_options?security_token=yo&user_name=mcarter&reflective=false
+
+
+Server Replies:
+
+.. sourcecode:: javascript
+
+    [ true, {} ]
+
+The ``reflective`` of the user is now `false`.

--- a/docs/source/web.rst
+++ b/docs/source/web.rst
@@ -120,6 +120,47 @@ Server Replies:
 And the user "mcarter" is unsubscribed from the channel "testing".
 
 
+message
+=======
+
+Publish a message to a user.
+
+Required Form Variables:
+
+* ``security_token``: The password specified in the config as ``-r`` or ``--api-security-token``.
+* ``sender_name``: The user name of the message sender.
+* ``recipient_name``: The user name of the message recipient.
+* ``payload``: The json payload to send
+
+Returns json:
+
+.. sourcecode:: javascript
+
+    [ success (boolean) , details (object) ]
+
+
+Example:
+
+Client Requests URL:
+
+.. sourcecode:: none
+
+    /web/message?security_token=yo&sender_name=bob&recipient_name=joe&payload=[1, 2, "foo"]
+
+
+Server Replies:
+
+.. sourcecode:: javascript
+
+    [ true, {} ]
+
+And the following message frame is sent to user 'joe':
+
+.. sourcecode:: javascript
+
+    { "sender": "bob", "recipient": "joe", "payload": [1, 2, "foo"] }
+
+
 get_channel_info
 ================
 

--- a/docs/source/webhooks.rst
+++ b/docs/source/webhooks.rst
@@ -1,5 +1,62 @@
 .. _webhooks_toplevel:
-    
+
+==================
 Webhooks
-========
+==================
+
+message
+=======
+
+Send a private message to a user.
+
+Webhook Form Variables:
+
+* ``sender``: The user name of the sending user.
+* ``recipient``: The user name of the receiving user.
+* ``payload``: The json payload to send to the
+
+Webhook post includes sender cookies.
+
+Returns json:
+
+.. sourcecode:: javascript
+
+    [ success (boolean) , details (object) ]
+
+
+Optional Webhook return details:
+
+* ``override_payload``: A new payload that will be send instead of the original payload.
+
+
+Example:
+
+Client Calls:
+
+.. sourcecode:: javascript
+
+    connection.message("mcarter", { title: "a message", body: "some text" });
+
+
+Webhook Called With:
+
+.. sourcecode:: javascript
+
+    { sender: "some_user", recipient: "mcarter", payload: { title: "a message", body: "some text" } }
+
+
+Webhook replies:
+
+.. sourcecode:: javascript
+
+    [ true, { override_payload: { title: "a new title", body: "some text" } } ]
+
+
+And the following frame is published to the user 'mcarter':
+
+.. sourcecode:: javascript
+
+    { sender: "some_user", recipient: "mcarter", "payload": { title: "a new title", body: "some text" } }
+
+
 

--- a/docs/source/webhooks.rst
+++ b/docs/source/webhooks.rst
@@ -13,7 +13,8 @@ Webhook Form Variables:
 
 * ``sender``: The user name of the sending user.
 * ``recipient``: The user name of the receiving user.
-* ``payload``: The json payload to send to the
+* ``recipient_exists``: True if the recipient name is that of a connected user, false otherwise.
+* ``payload``: The json payload to send to the receiving user.
 
 Webhook post includes sender cookies.
 
@@ -26,7 +27,8 @@ Returns json:
 
 Optional Webhook return details:
 
-* ``override_payload``: A new payload that will be send instead of the original payload.
+* ``override_payload``: A new payload that will be sent instead of the original payload.
+* ``override_recipient_name``: The name of a user to send the message to instead of the original reciepient.
 
 
 Example:

--- a/hookbox/api/internal.py
+++ b/hookbox/api/internal.py
@@ -43,6 +43,11 @@ class HookboxAPI(object):
         user = self.server.get_user(name)
         channel.subscribe(user, needs_auth=send_hook)
 
+    def message(self, sender_name, recipient_name, payload='null', send_hook=False):
+        if not self.server.exists_user(sender_name):
+            raise ExpectedException("User %s doesn't exist" % (sender_name,))
+        sender = self.server.get_user(sender_name)
+        sender.send_message(recipient_name, payload, needs_auth=send_hook)
 
     def disconnect_user(self, name):
         raise ExpectedException("Not Implemented")

--- a/hookbox/api/internal.py
+++ b/hookbox/api/internal.py
@@ -50,6 +50,18 @@ class HookboxAPI(object):
             raise ExpectedException("User %s doesn't exist" % (name,))
         user = self.server.get_user(name)
         # TODO: disconnect the user
+
+    def set_user_options(self, user_name, options):
+        if not self.server.exists_user(user_name):
+            raise ExpectedException("User %s doesn't exists" % (user_name,))
+        user = self.server.get_user(user_name)
+        user.update_options(**options)
+
+    def get_user_info(self, user_name):
+        if not self.server.exists_user(user_name):
+            raise ExpectedException("User %s doesn't exists" % (user_name,))
+        user = self.server.get_user(user_name)
+        return user.serialize()
         
     def disconnect(self, identifier):
         raise ExpectedException("Not Implemented")

--- a/hookbox/api/web.py
+++ b/hookbox/api/web.py
@@ -85,6 +85,27 @@ class HookboxWebAPI(object):
         start_response('200 Ok', [])
         return json.dumps([True, {}])
 
+    def render_set_user_options(self, form, start_response):
+        user_name = form.pop('user_name', None)
+        if not user_name:
+            raise ExpectedException("Missing user_name")
+        for key, val in form.items():
+            try:
+                form[key] = json.loads(val)
+            except:
+                raise ExpectedException("Invalid json value for option %s" % (key,))
+        self.api.set_user_options(user_name, form)
+        start_response('200 Ok', [])
+        return json.dumps([True, {}])
+
+    def render_get_user_info(self, form, start_response):
+        user_name = form.get('user_name', None)
+        if not user_name:
+            raise ExpectedException("Missing user_name")
+        info = self.api.get_user_info(user_name)
+        start_response('200 Ok', [])
+        return json.dumps([True, info])
+
     def render_disconnect(self, form, start_response):
         identifier = form.get('identifier', None)
         self.api.disconnect(identifier)

--- a/hookbox/api/web.py
+++ b/hookbox/api/web.py
@@ -85,6 +85,20 @@ class HookboxWebAPI(object):
         start_response('200 Ok', [])
         return json.dumps([True, {}])
 
+    def render_message(self, form, start_response):
+        sender_name = form.get('sender_name', None)
+        if not sender_name:
+            raise ExpectedException("Missing sender_name")
+        recipient_name = form.get('recipient_name', None)
+        if not recipient_name:
+            raise ExpectedException("Missing recipient_name")
+        payload = form.get('payload', 'null')
+        send_hook = form.get('send_hook', '0') == '1'
+        
+        self.api.message(sender_name, recipient_name, payload, send_hook)
+        start_response('200 Ok', [])
+        return json.dumps([True, {}])
+
     def render_set_user_options(self, form, start_response):
         user_name = form.pop('user_name', None)
         if not user_name:

--- a/hookbox/protocol.py
+++ b/hookbox/protocol.py
@@ -134,12 +134,12 @@ class HookboxConn(object):
             return self.send_error(fid, "Not connected")
         if 'name' not in fargs:
             return self.send_error(fid, "name")
-        user_name = fargs['name']
-        if not self.server.exists_user(user_name):
+        recipient_user_name = fargs['name']
+        if not self.server.exists_user(recipient_user_name):
             # TODO: Maybe this is too much info to expose, that the user isn't signed on...
             return self.send_error(fid, "invalid user name")
-        user = self.server.get_user(user_name)
-        user.send_message(self.user, fargs.get('payload', 'null'), conn=self)
+        recipient = self.server.get_user(recipient_user_name)
+        self.user.send_message(recipient, fargs.get('payload', 'null'), conn=self)
         
         
 def parse_cookies(cookieString):

--- a/hookbox/protocol.py
+++ b/hookbox/protocol.py
@@ -139,7 +139,7 @@ class HookboxConn(object):
             # TODO: Maybe this is too much info to expose, that the user isn't signed on...
             return self.send_error(fid, "invalid user name")
         user = self.server.get_user(user_name)
-        user.send_message(self.user.get_name(), fargs.get('payload', 'null'))
+        user.send_message(self.user, fargs.get('payload', 'null'), conn=self)
         
         
 def parse_cookies(cookieString):

--- a/hookbox/protocol.py
+++ b/hookbox/protocol.py
@@ -133,13 +133,8 @@ class HookboxConn(object):
         if self.state != 'connected':
             return self.send_error(fid, "Not connected")
         if 'name' not in fargs:
-            return self.send_error(fid, "name")
-        recipient_user_name = fargs['name']
-        if not self.server.exists_user(recipient_user_name):
-            # TODO: Maybe this is too much info to expose, that the user isn't signed on...
-            return self.send_error(fid, "invalid user name")
-        recipient = self.server.get_user(recipient_user_name)
-        self.user.send_message(recipient, fargs.get('payload', 'null'), conn=self)
+            return self.send_error(fid, "name required")
+        self.user.send_message(fargs['name'], fargs.get('payload', 'null'), conn=self)
         
         
 def parse_cookies(cookieString):

--- a/hookbox/server.py
+++ b/hookbox/server.py
@@ -252,6 +252,8 @@ class HookboxServer(object):
             raise ExpectedException('Unauthorized (missing name parameter in server response)')
         self.conns[conn.id] = conn
         user = self.get_user(options['name'])
+        del options['name']
+        user.update_options(**options)
         user.add_connection(conn)
         self.admin.user_event('connect', user.get_name(), conn.serialize())
         self.admin.connection_event('connect', conn.id, conn.serialize())
@@ -268,6 +270,7 @@ class HookboxServer(object):
         
     def exists_user(self, name):
         return name in self.users
+
     def get_user(self, name):
         if name not in self.users:
             self.users[name] = User(self, name)
@@ -299,7 +302,7 @@ class HookboxServer(object):
             if success:
                 options.update(callback_options)
             else:
-                raise ExpectedException(options.get('error', 'Unauthorized'))
+                raise ExpectedException(callback_options.get('error', 'Unauthorized'))
         chan = self.channels[channel_name] = channel.Channel(self, channel_name, **options)
         self.admin.channel_event('create_channel', channel_name, chan.serialize())
 


### PR DESCRIPTION
These commits flesh out the implementation of the private messaging functionality, which can help simplify implementations of one-to-one publishing. The main changes are:
- The "message" web hook is now passed the sender's cookies, and both the sender and recipient user names. This allows the web hook to perform validation on the sending user based on the cookie data.
- The message frame is delivered to the recipient, then to the sender as well. This addresses one of the difficulties in implementing private messaging using a single dedicated channel per user, where there is not a particularly good way to echo the message back to the sender.
- User#send_message now calls the web hook for all requests. 

The second and third changes listed above could benefit from some additional configuration options at the user level (i.e.: returned along with the "name" option from the connect web hook). However, they are not included in these changes as they would require some larger additions to User. They are:
- "reflective" - whether messages sent by this user should be sent back to the user.
- "moderated_message" whether the web hook should be called when this user tries to send a message.
