### PR TITLE
Add option to always append a trailing slash to the callback URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 *.egg-info
+build
+dist

--- a/hookbox/config.py
+++ b/hookbox/config.py
@@ -86,6 +86,10 @@ class HookboxOptionParser(object):
                           dest="cbhttps", action="store_true",
                           default=defaults._cbhttps, metavar="HTTPS",
                           help="Use https (instead of http) to make callbacks.")
+        parser.add_option("--cbtrailingslash",
+                          dest="cbtrailingslash", action="store_true",
+                          default=defaults._cbtrailingslash,
+                          help="Append a trailing slash to the callback URL.")
     
     def _add_callback_path_options(self, parser, defaults):
         parser.add_option('--cb-connect', 
@@ -162,6 +166,7 @@ class HookboxConfig(object):
     defaults._cookie_identifier = NoDefault()
     defaults._webhook_secret = NoDefault()
     defaults._cbhttps = False
+    defaults._cbtrailingslash = False
     defaults._cb_connect = 'connect'
     defaults._cb_disconnect = 'disconnect'
     defaults._cb_create_channel = 'create_channel'

--- a/hookbox/server.py
+++ b/hookbox/server.py
@@ -162,6 +162,8 @@ class HookboxServer(object):
             host = u.hostname
             port = u.port or 80
             path = u.path
+            if self.config['cbtrailingslash'] and not path.endswith('/'):
+                path += '/'
             if u.query:
                 path += '?' + u.query
         else:
@@ -170,6 +172,8 @@ class HookboxServer(object):
 #                host = self.base_host
 #            else:
             path = self.base_path + '/' + self.config.get('cb_' + path_name)
+            if self.config['cbtrailingslash'] and not path.endswith('/'):
+                path += '/'
             scheme = self.config["cbhttps"] and "https" or "http"
             host = self.config["cbhost"]
             port = self.config["cbport"]

--- a/hookbox/server.py
+++ b/hookbox/server.py
@@ -158,10 +158,7 @@ class HookboxServer(object):
             full_path = self.config['cb_single_url']
         if full_path:
             u = urlparse.urlparse(full_path)
-            scheme = u.scheme
-            host = u.hostname
-            port = u.port or 80
-            path = u.path
+            scheme, host, port, path = u.scheme, u.hostname, u.port or 80, u.path
             if self.config['cbtrailingslash'] and not path.endswith('/'):
                 path += '/'
             if u.query:
@@ -198,11 +195,9 @@ class HookboxServer(object):
 
         # for logging
         if port != 80:
-            url = urlparse.urlunparse((scheme,host + ":" + str(port), '', '','',''))
-        else:
-            url = urlparse.urlunparse((scheme,host, '', '','',''))
-       
-        
+            host = "%s:%s" % (host, port)
+        url = urlparse.urlunparse((scheme, host, '', '', '', ''))
+
         headers = {'content-type': 'application/x-www-form-urlencoded'}
         if cookie_string:
             headers['Cookie'] = cookie_string


### PR DESCRIPTION
This adds an option (--cbtrailingslash) to ensure that the callback URL ends with a slash. This is especially useful if that callback differentiates between having a slash and not having a slash and does a few things to actually enforce the trailing slash. Like Django :)
