### PR TITLE
maybe_auto_subscribe was not passing a conn object into get_channel

### DIFF
--- a/hookbox/channel.py
+++ b/hookbox/channel.py
@@ -242,7 +242,18 @@ class Channel(object):
             return
         self.state[key] = val
         self.state_broadcast(updates={ key: val })
-    
+
+    def state_multi_set(self, state):
+        #Set multiple state values at once
+        updates = {}
+        for k,v in state.iteritems():
+            if k in self.state and self.state[k]==v:
+                pass
+            else:
+                self.state[k] = v
+                updates[k] = v
+        self.state_broadcast(updates=updates)
+
     def state_broadcast(self, updates={}, deletes=[]):
         frame = { 
             "channel_name": self.name, 

--- a/hookbox/channel.py
+++ b/hookbox/channel.py
@@ -22,6 +22,8 @@ class Channel(object):
         'moderated_subscribe': False,
         'moderated_unsubscribe': False,
         'presenceful': False,
+        'server_presenceful': False,
+        'server_user_presence': [],
         'anonymous': False,
         'polling': {
             'mode': "",

--- a/hookbox/protocol.py
+++ b/hookbox/protocol.py
@@ -60,7 +60,7 @@ class HookboxConn(object):
 #                print 'read a frame...'
                 self.logger.debug('%s waiting for a frame', self)
                 fid, fname, fargs= self._rtjp_conn.recv_frame().wait()
-                print 'got frame', fid, fname, fargs
+#                print 'got frame', fid, fname, fargs
             except rtjp_eventlet.errors.ConnectionLost, e:
                 self.logger.debug('received connection lost error')
 #                print 'connection lost'

--- a/hookbox/protocol.py
+++ b/hookbox/protocol.py
@@ -135,24 +135,7 @@ class HookboxConn(object):
         if 'name' not in fargs:
             return self.send_error(fid, "name required")
         self.user.send_message(fargs['name'], fargs.get('payload', 'null'), conn=self)
-
-    def frame_EXISTS_USERS(self, fid, fargs):
-        if self.state != 'connected':
-            return self.send_error(fid, "Not connected")
-        if 'name' not in fargs:
-            return self.send_error(fid, "name required")
-        if 'response_channel' not in fargs:
-            return self.send_error(fid, "response_channel required")
-        if 'users' not in fargs:
-            return self.send_error(fid, "users required")
-
-        exists_users = []
-        for user in fargs['users']:
-            exists_users.append({'name':user, 'status':user in self.server.users})
-
-        payload = {'frame_type':'exists_users', 'data':exists_users}
-
-        self.send_frame('PUBLISH', {'channel_name':fargs['response_channel'], 'payload':payload})
+        
         
 def parse_cookies(cookieString):
     output = {}

--- a/hookbox/server.py
+++ b/hookbox/server.py
@@ -300,6 +300,7 @@ class HookboxServer(object):
                 self.logger.warn("Unexpected error when removing user: %s", e, exc_info=True)
         
     def create_channel(self, conn, channel_name, options={}, needs_auth=True):
+        local_options = options.copy()
         if channel_name in self.channels:
             raise ExpectedException("Channel already exists")
         if needs_auth:
@@ -309,10 +310,11 @@ class HookboxServer(object):
             }
             success, callback_options = self.http_request('create_channel', cookie_string, form)
             if success:
-                options.update(callback_options)
+                local_options.update(callback_options)
             else:
                 raise ExpectedException(callback_options.get('error', 'Unauthorized'))
-        chan = self.channels[channel_name] = channel.Channel(self, channel_name, **options)
+
+        chan = self.channels[channel_name] = channel.Channel(self, channel_name, **local_options)
         self.admin.channel_event('create_channel', channel_name, chan.serialize())
 
     def destroy_channel(self, channel_name, needs_auth=True):

--- a/hookbox/server.py
+++ b/hookbox/server.py
@@ -333,12 +333,13 @@ class HookboxServer(object):
 
     def maybe_auto_subscribe(self, user, options, conn=None):
         #print 'maybe autosubscribe....'
+        use_conn = conn if conn else user
         for destination in options.get('auto_subscribe', ()):
             #print 'subscribing to', destination
-            channel = self.get_channel(user, destination)
+            channel = self.get_channel(use_conn, destination)
             channel.subscribe(user, conn=conn, needs_auth=False)
         for destination in options.get('auto_unsubscribe', ()):
-            channel = self.get_channel(user, destination)
+            channel = self.get_channel(use_conn, destination)
             channel.unsubscribe(user, conn=conn, needs_auth=False)
 
 

--- a/hookbox/user.py
+++ b/hookbox/user.py
@@ -13,6 +13,7 @@ class User(object):
     _options = {
         'reflective': True,
         'moderated_message': True,
+        'auto_subscribe': []
     }
 
     def __init__(self, server, name, **options):


### PR DESCRIPTION
maybe_auto_subscribe in server.py was not passing in a conn object to the get_channel calls.

In most cases this isn't an issue, except when the autosubscribe channel in question requires a cookie for authorization.  Without the conn object, creating the cookie for a potential create_channel rest call was not happening.

the get_channel calls in maybe_auto_subscribe now use the conn argument, if available, otherwise reverting to the current standard of using the user argument.
