### PR TITLE
Option to only log publish messages to history

### DIFF
--- a/hookbox/channel.py
+++ b/hookbox/channel.py
@@ -17,6 +17,7 @@ class Channel(object):
         'reflective': True,
         'history': [],
         'history_size': 0,
+        'history_publish_only': False,
         'moderated': True,
         'moderated_publish': False,
         'moderated_subscribe': False,
@@ -227,7 +228,7 @@ class Channel(object):
         
         user.send_frame('SUBSCRIBE', frame)
             
-        if self.history_size:
+        if self.history_size and not self.history_publish_only:
             self.history.append(('SUBSCRIBE', {"user": user.get_name(), "datetime": _now }))
             self.prune_history()
 
@@ -319,7 +320,7 @@ class Channel(object):
         user.send_frame('UNSUBSCRIBE', frame)
         self.subscribers.remove(user)
         user.channel_unsubscribed(self)
-        if self.history_size:
+        if self.history_size and not self.history_publish_only:
             del frame['channel_name']
             self.history.append(('UNSUBSCRIBE', frame))
             self.prune_history()


### PR DESCRIPTION
I had a situation where I didn't care about subscribe/unsubscribe messages being logged in the hookbox channel history. So I made an option you can set to disable logging of subscribe/unsubscribe messages. It only logs publish messages to the history. Not sure if history_publish_only is a good name for it or not.
